### PR TITLE
Update aurutils

### DIFF
--- a/polybar.conf.d/updates-aur.sh
+++ b/polybar.conf.d/updates-aur.sh
@@ -9,5 +9,5 @@
 # install:set type=user path=$HOME/.config/polybar/updates-aur.sh
 
 # Updates: Arch User Repository (aurutils)
-updates_aur=$(aurcheck -d aur 2> /dev/null | wc -l) || "0"
+updates_aur=$(aur repo -u 2> /dev/null | wc -l) || "0"
 echo "$updates_aur"

--- a/runcom/functions
+++ b/runcom/functions
@@ -76,7 +76,7 @@ function checkupdates
   local aor_updates=$(/usr/bin/checkupdates)
   local aor_num=$(wc -l <<< "$aor_updates")
 
-  local aur_updates=$(/usr/bin/aurcheck -d aur)
+  local aur_updates=$(/usr/bin/aur repo -u)
   local aur_num=$(wc -l <<< "$aur_updates")
 
   echo


### PR DESCRIPTION
Recent updates to AUR Utils changed the path of most executables and introduced a wrapper script to handle most functions. This broke several calls within functions and update checks that referred to the old commands.