### PR TITLE
Update Startup Script

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -28,7 +28,7 @@ printf $'\n'
 
 # Load Custom udev Rules
 printa "Triggering custom udev rules"
-sudo udevadm control --reload-rules && udevadm trigger && \
+sudo udevadm control --reload-rules && sudo udevadm trigger && \
 sleep 1 && \
 printn "Custom rules successfully loaded" || \
 printe "Failed to load custom rules"


### PR DESCRIPTION
A recent update to udev seems to have changed `udevadm trigger` to require elevated permissions, so it is now being called with `sudo`.