### PR TITLE
Update Volume Control

### DIFF
--- a/i3-gaps.conf
+++ b/i3-gaps.conf
@@ -241,8 +241,10 @@ bindsym $mod+Shift+e exec --no-startup-id "i3-nagbar -t warning -m 'You pressed 
 
 # Lenovo Yoga 2 Pro - Top Row Keybinds
 bindsym XF86AudioMute exec --no-startup-id "volumectl tog"
-bindsym XF86AudioLowerVolume exec --no-startup-id "volumectl dec"
-bindsym XF86AudioRaiseVolume exec --no-startup-id "volumectl inc"
+bindsym XF86AudioLowerVolume exec --no-startup-id "volumectl dec 10"
+bindsym XF86AudioRaiseVolume exec --no-startup-id "volumectl inc 10"
+bindsym Shift+XF86AudioLowerVolume exec --no-startup-id "volumectl dec 5"
+bindsym Shift+XF86AudioRaiseVolume exec --no-startup-id "volumectl inc 5"
 bindsym Mod1+F4 kill
 #bindsym XF86TouchpadToggle
 bindsym Mod1+Tab workspace next

--- a/scripts/volumectl.sh
+++ b/scripts/volumectl.sh
@@ -36,11 +36,6 @@ function validate_input
   fi
 }
 
-function set_vol_step
-{
-  vol_step=$1
-}
-
 function get_vol
 {
   pactl list sinks | grep '^\s*Volume' | awk '{print $5}' | sed s/%//g
@@ -66,13 +61,13 @@ function increase_volume
   if [[ $(get_vol) -ge $vol_max ]]; then
     pactl set-sink-volume 0 150%
   else
-    pactl set-sink-volume 0 +${vol_step}%
+    pactl set-sink-volume 0 +${1}%
   fi
 }
 
 function decrease_volume
 {
-  pactl set-sink-volume 0 -${vol_step}%
+  pactl set-sink-volume 0 -${1}%
 }
 
 # ===========================
@@ -141,14 +136,12 @@ case "$1" in
   dec)
     validate_input $1 $2
     unmute
-    set_vol_step $2
-    decrease_volume
+    decrease_volume $2
     ;;
   inc)
     validate_input $1 $2
     unmute
-    set_vol_step $2
-    increase_volume
+    increase_volume $2
     ;;
   get)
     ;;

--- a/scripts/volumectl.sh
+++ b/scripts/volumectl.sh
@@ -95,10 +95,12 @@ function display_notification
   # Build Volume Bar
   function get_symbol
   {
-    if [[ $(( vol_step % 10 )) -ne 0 && $vol_current -eq $(( $1 - $vol_step )) ]]; then
-      echo $step_fill_type
-    elif [[ $1 -le $vol_current ]]; then
+    local vol_diff=$(( vol_current % 10 ))
+
+    if [[ $1 -le $vol_current ]]; then
       echo $main_fill_type
+    elif [[ $vol_diff -ne 0 && $vol_current -eq $(( $1 - $vol_diff )) ]]; then
+      echo $step_fill_type
     else
       echo $symbol_empty
     fi
@@ -137,13 +139,13 @@ case "$1" in
     toggle_mute_state
     ;;
   dec)
-    validate_input dec $2
+    validate_input $1 $2
     unmute
     set_vol_step $2
     decrease_volume
     ;;
   inc)
-    validate_input inc $2
+    validate_input $1 $2
     unmute
     set_vol_step $2
     increase_volume


### PR DESCRIPTION
Quick update to the `volumectl` script that handles volume bar notifications. Changed it so that the volume step needs to be specified when calling it at the command line with either `inc` or `dec`.

```
$ volumectl inc 10
```
###### <sup>- Increases volume by 10%</sup>

This was done to be able to easily add shift modifiers to the volume keymaps in `i3-gaps.conf` to alter volume levels by a smaller amount, in this case `5%`.