### PR TITLE
Disable Bluetooth Keymaps

### DIFF
--- a/i3-gaps.conf
+++ b/i3-gaps.conf
@@ -224,8 +224,8 @@ mode $systemMode
 bindsym $mod+Escape mode $systemMode
 
 # Bluetooth Toggles
-#bindsym $mod+b exec --no-startup-id
-bindsym $mod+Shift+b exec --no-startup-id btconnect
+# bindsym $mod+b exec --no-startup-id
+# bindsym $mod+Shift+b exec --no-startup-id btconnect
 
 # Lock Computer
 bindsym $mod+Shift+x exec --no-startup-id betterlockscreen -l blur


### PR DESCRIPTION
Disables <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>B</kbd> in `i3-gaps.conf` as it's no longer needed :tada:

---
I found `fix-bt-a2dp`<sup>**[AUR](https://aur.archlinux.org/packages/fix-bt-a2dp/)**</sup> that accomplishes the same goal as my `btconnect` script, essentially automating the pairing process of bluetooth headsets via `bluetoothctl` to enable the `A2DP sink profile` for the headset.

Downside of my own script is it uses the MAC address of the specific headset statically, and needs to be run manually (via <kbd>Ctrl</kbd>-<kbd>Shift</kbd>-<kbd>B</kbd>). This script will work on any headset and triggers right away.
