### PR TITLE
Update Shell

### DIFF
--- a/i3-gaps.conf
+++ b/i3-gaps.conf
@@ -49,10 +49,6 @@ gaps inner 4
 gaps outer 0
 gaps horizontal 3
 gaps vertical 0
-# gaps top
-# gaps right
-# gaps bottom
-# gaps left
 
 
 

--- a/runcom/env
+++ b/runcom/env
@@ -57,3 +57,6 @@ export LESS_TERMCAP_me=$(printf '\e[0m')       # Exit All
 
 # Remove Inverted Bold %
 export PROMPT_EOL_MARK=""
+
+# Fix Required By Patched Versions of Rxvt-Unicode
+unset LD_PRELOAD

--- a/runcom/env
+++ b/runcom/env
@@ -20,7 +20,7 @@ export PAGER=less
 export ZDOTDIR=$HOME
 export GEM_HOME=$HOME/.gem
 export DOTFILES_DIR=$HOME/.dotfiles
-export FIGLET_FONTDIR=$HOME/.local/share/fonts/figlet-fonts/contributed/
+# export FIGLET_FONTDIR=$HOME/.local/share/fonts/figlet-fonts/contributed/
 
 # Video Acceleration
 export LIBVA_DRIVER_NAME=i965

--- a/runcom/prompt/arclight.zsh-theme
+++ b/runcom/prompt/arclight.zsh-theme
@@ -28,7 +28,7 @@ ZSH_THEME_GIT_PROMPT_AHEAD="%{$fg[blue]%}▲%{$reset_color%} "
 # ================================
 local working_dir="[%{$fg[cyan]%}%1~%{$reset_color%}]"
 local exit_code="%{$fg[red]%}%(?..%? )%{$reset_color%}"
-local prompt_char="%{$fg[green]%}»%{$reset_color%}"
+local prompt_char="%{$fg_bold[green]%}»%{$reset_color%}"
 
 PROMPT='${working_dir} ${exit_code}${prompt_char} ' # ┌╼ └───╼➤
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -28,6 +28,9 @@ set -g renumber-windows on
 set -g set-titles on
 set -g default-terminal "screen-256color"
 
+# Enable Mouse Scrollback
+set -g mouse on
+
 # Status Bar - TODO: FA Icon on status-left
 set -g status-fg colour6
 set -g status-bg colour0

--- a/tmux.conf
+++ b/tmux.conf
@@ -31,8 +31,8 @@ set -g default-terminal "screen-256color"
 # Status Bar - TODO: FA Icon on status-left
 set -g status-fg colour6
 set -g status-bg colour0
-set -g status-left '#[fg=colour0,bg=colour6] » #[fg=colour6,bg=colour0] '
-set -g status-right '#{?client_prefix,#[fg=colour2]prefix#[fg=colour6],prefix} #[fg=colour6,bg=colour0]#[fg=colour0,bg=colour6] vi-#(~/.dotfiles/tmux.conf.d/status-right-vimode.sh)  #(~/.dotfiles/tmux.conf.d/status-right-process.sh) '
+set -g status-left '#[fg=colour0,bg=colour6,bold] » #[fg=colour6,bg=colour0] '
+set -g status-right '#{?client_prefix,#[fg=colour2]prefix#[fg=colour6],prefix} #[fg=colour6,bg=colour0]#[fg=colour0,bg=colour6,bold] vi-#(~/.dotfiles/tmux.conf.d/status-right-vimode.sh)  #(~/.dotfiles/tmux.conf.d/status-right-process.sh) '
 
 # Status Bar Padding
 setw -g pane-border-status bottom

--- a/tmux.conf
+++ b/tmux.conf
@@ -41,7 +41,7 @@ setw -g pane-border-format '─'
 # Active Window/Tab
 setw -g window-status-current-fg colour2
 setw -g window-status-current-bg colour0
-setw -g window-status-current-format '#[fg=colour0,bg=colour2]#[fg=colour0] #I  #W #[fg=colour2,bg=colour0]'
+setw -g window-status-current-format '#[fg=colour0,bg=colour2,bold]#[fg=colour0] #I  #W #[fg=colour2,bg=colour0]'
 
 # Inactive Window/Tab
 setw -g window-status-fg colour6

--- a/vimrc
+++ b/vimrc
@@ -103,7 +103,7 @@ call airline#parts#define_raw('colnr', '%c')
 call airline#parts#define_accent('colnr', 'bold')
 let g:airline_section_x = airline#section#create_right(['%{&fileformat}', '%{&fileencoding?&fileencoding:&encoding}'])
 let g:airline_section_y = airline#section#create_right(['tagbar', 'gutentags', 'filetype'])
-let g:airline_section_z = airline#section#create(['« %p%%', '   ', 'linenr', '   ', 'colnr'])
+let g:airline_section_z = airline#section#create(['« %p%%', '   ', 'linenr', ':', 'colnr', ' '])
 
 " Custom Mode Text
 "let g:airline_mode_map = {

--- a/vimrc
+++ b/vimrc
@@ -32,6 +32,7 @@ Plugin 'tpope/vim-fugitive'                 " Fugitive
 Plugin 'scrooloose/nerdtree'                " Nerd Tree
 Plugin 'joshdick/onedark.vim'               " One Dark Colour Theme
 Plugin 'dracula/vim'                        " Dracula Colour Theme
+Plugin 'ryanoasis/vim-devicons'             " Vim DevIcons
 call vundle#end()                           " </plugins>
 
 " ===============================


### PR DESCRIPTION
Some patched versions of `urxvt` use an environment variable `LD_PRELOAD` to link a shared object file containing the patch. This environment variable seems to interfere with certain utilities, namely `man` which can no longer be run without elevated privileges. Unsetting `LD_PRELOAD` solves this.

Also added `vim-devicons` to Vim and some small updates to tmux's status bar.