### PR TITLE
Update Tmux

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -52,3 +52,7 @@ setw -g window-status-current-format '#[fg=colour0,bg=colour2,bold]#[fg=colou
 setw -g window-status-fg colour6
 setw -g window-status-bg colour0
 setw -g window-status-format '#[fg=colour0,bg=colour6]#[fg=colour0] #I  #W #[fg=colour6,bg=colour0]'
+
+# Command Line & Messages
+set -g message-fg colour0
+set -g message-bg colour2

--- a/tmux.conf
+++ b/tmux.conf
@@ -14,6 +14,12 @@
 unbind C-b
 set -g prefix C-t
 
+# Pane Splits
+unbind '"'
+bind v split-window -v
+unbind %
+bind h split-window -h
+
 # Reload Config Keymap
 bind R source-file ~/.tmux.conf \; display-message "Successfully reloaded tmux config"
 

--- a/tmux.conf
+++ b/tmux.conf
@@ -26,12 +26,14 @@ set -g renumber-windows on
 
 # Enable Window Titles
 set -g set-titles on
+
+# Set Correct TERM
 set -g default-terminal "screen-256color"
 
 # Enable Mouse Scrollback
 set -g mouse on
 
-# Status Bar - TODO: FA Icon on status-left
+# Status Bar
 set -g status-fg colour6
 set -g status-bg colour0
 set -g status-left '#[fg=colour0,bg=colour6,bold] » #[fg=colour6,bg=colour0] '

--- a/zshrc
+++ b/zshrc
@@ -68,14 +68,14 @@ SAVEHIST=1000
 bindkey -v
 
 # History Substring Search
-bindkey '^[[A' history-substring-search-up
-bindkey '^[[B' history-substring-search-down
+bindkey "$terminfo[kcuu1]" history-substring-search-up
+bindkey "$terminfo[kcud1]" history-substring-search-down
 
 # Directory Navigation
-bindkey '^[^[[D' dir-back
-bindkey '^[^[[A' dir-parent
-bindkey '^[^[[B' dir-save
-bindkey '^[^[[C' dir-goto
+bindkey "^[$terminfo[kcub1]" dir-back
+bindkey "^[$terminfo[kcuu1]" dir-parent
+bindkey "^[$terminfo[kcud1]" dir-save
+bindkey "^[$terminfo[kcuf1]" dir-goto
 
 # Auto cd
 setopt autocd


### PR DESCRIPTION
Tmux wasn't recognising my zsh key binds, which were using xterm's raw escape sequences. This worked fine in urxvt, but tmux recognises a different set of sequences for the keys in question. Solved this by using the terminfo database (which will work regardless of terminal).

Some other minor edits to settings as well.